### PR TITLE
add a helper function for flattening a prototype chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ A helper function used internally but exposed for convenience. It uses the
 native methods on Object for getting a list of property names and property
 descriptors and creates a map. The main purpose is to feed the second argument
 of [`Object.create()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create).
+
+### `extend.flatten(object[, base]) -> Object`
+
+A helper function that takes a prototype chain and flattens it into a new single
+object. This is useful if you are passing a prototypal-extended object to a
+library that intentionally iterates over only "own" keys. If you specify a
+`base`, it will stop flattening when it reaches a prototype of that object. By
+default, this is `Object.prototype`, though it will always stop if it reaches
+the `null` prototype.

--- a/lib/proto-extend.js
+++ b/lib/proto-extend.js
@@ -1,3 +1,5 @@
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 var extend = function(){
   var base = arguments[0];
   var extensions = Array.prototype.slice.call(arguments, 1);
@@ -24,5 +26,32 @@ var getOwnPropertyDescriptorMap = function(object){
   }, Object.create(null));
 };
 
+var flatten = function(object, base){
+  if (typeof base === 'undefined') {
+    base = Object.prototype;
+  }
+  return _flatten(object, base, {});
+}
+
+var _flatten = function(object, base, descriptors){
+  merge(descriptors, getOwnPropertyDescriptorMap(object));
+
+  var proto = Object.getPrototypeOf(object);
+  if (proto === base || proto === null) {
+    return Object.create(proto, descriptors);
+  }
+  return _flatten(proto, base, descriptors);
+};
+
+var merge = function(dest, source) {
+  Object.keys(source).forEach(function(key) {
+    if (!hasOwnProperty.call(dest, key)) {
+      dest[key] = source[key];
+    }
+  });
+  return;
+};
+
 module.exports = extend;
 module.exports.getOwnPropertyDescriptorMap = getOwnPropertyDescriptorMap;
+module.exports.flatten = flatten;


### PR DESCRIPTION
This may be useful if you want to use a built-up prototype chain with
another component that only examines own properties and ignores the
prototype chain.

Not sure if it is worth merging yet.
